### PR TITLE
Support configurable game setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -1,0 +1,104 @@
+import pytest
+
+from wargame.map import Map, Terrain
+from wargame.player import Player
+from wargame.game import Game
+from wargame.config import GameConfig
+
+
+def test_map_determinism():
+    m1 = Map(5, 5, seed=42, players=2)
+    m2 = Map(5, 5, seed=42, players=2)
+    for coord in m1.hexes:
+        h1 = m1.hexes[coord]
+        h2 = m2.hexes[coord]
+        assert h1.terrain == h2.terrain
+        assert h1.structure == h2.structure
+
+
+def setup_income_scenario() -> Game:
+    p1 = Player("A")
+    p2 = Player("B")
+    game = Game.create([p1, p2], width=10, height=10, seed=1)
+    # clear map
+    for h in game.game_map.hexes.values():
+        h.owner = None
+        h.structure = None
+        h.terrain = Terrain.PLAIN
+    game.game_map.capitals = [(0, 0)]
+    cap = (0, 0)
+    game.game_map.get_hex(cap).owner = "A"
+    game.game_map.get_hex(cap).structure = Terrain.CITY_CAPITAL
+    # City large and smalls
+    large = (1, 0)
+    small1 = (2, 0)
+    small2 = (3, 0)
+    game.game_map.get_hex(large).owner = "A"
+    game.game_map.get_hex(large).structure = Terrain.CITY_LARGE
+    game.game_map.get_hex(small1).owner = "A"
+    game.game_map.get_hex(small1).structure = Terrain.CITY_SMALL
+    game.game_map.get_hex(small2).owner = "A"
+    game.game_map.get_hex(small2).structure = Terrain.CITY_SMALL
+    # Oil wells and station
+    well1 = (0, 1)
+    well2 = (1, 1)
+    station = (2, 1)
+    for w in [well1, well2]:
+        game.game_map.get_hex(w).owner = "A"
+        game.game_map.get_hex(w).structure = Terrain.OIL_WELL
+    game.game_map.get_hex(station).owner = "A"
+    game.game_map.get_hex(station).structure = Terrain.STATION
+    special = {cap, large, small1, small2, well1, well2, station}
+    # Add 24 territory hexes
+    count = 0
+    for coord in game.game_map.hexes:
+        if coord in special:
+            continue
+        game.game_map.get_hex(coord).owner = "A"
+        count += 1
+        if count == 24:
+            break
+    return game
+
+
+def test_income_example():
+    game = setup_income_scenario()
+    player = game.players["A"]
+    dinero, petroleo = game.calcular_ingresos(player)
+    assert dinero == 182
+    assert petroleo == 22
+
+
+def test_move_consumes_oil_and_claims_territory():
+    p1 = Player("A")
+    p2 = Player("B")
+    game = Game.create([p1, p2], width=5, height=5, seed=1)
+    unit = p1.add_unit("RECON", p1.capital)
+    path = [(p1.capital[0] + 1, p1.capital[1])]
+    before_oil = p1.oil
+    game.mover_unidad(p1, unit, path)
+    assert unit.position == path[-1]
+    assert p1.oil < before_oil
+    assert game.game_map.get_hex(unit.position).owner == "A"
+
+
+def test_capture_capital_transfers_units():
+    p1 = Player("A")
+    p2 = Player("B")
+    game = Game.create([p1, p2], width=5, height=5, seed=1)
+    defender_unit = p2.add_unit("INF_BASIC", (1, 1))
+    attacker_unit = p1.add_unit("INF_BASIC", game.game_map.capitals[1])
+    game.capturar_capital(attacker_unit)
+    assert not p2.alive
+    assert defender_unit in p1.units
+
+
+def test_game_is_configurable():
+    cfg = GameConfig(width=8, height=7, seed=99, players=["Alice", "Bob", "Carol"], money=500, oil=200)
+    game = cfg.create_game()
+    assert game.game_map.width == 8
+    assert game.game_map.height == 7
+    assert set(game.players.keys()) == {"Alice", "Bob", "Carol"}
+    assert all(p.money == 500 and p.oil == 200 for p in game.players.values())
+    # ensure correct number of capitals placed
+    assert len(game.game_map.capitals) == 3

--- a/wargame/__init__.py
+++ b/wargame/__init__.py
@@ -1,0 +1,19 @@
+"""Core package for turn-based WWII strategy game."""
+
+from .game import Game
+from .player import Player
+from .units import Unit, UnitType, UNIT_TYPES
+from .map import Map, Terrain, Hex
+from .config import GameConfig
+
+__all__ = [
+    "Game",
+    "Player",
+    "Unit",
+    "UnitType",
+    "UNIT_TYPES",
+    "Map",
+    "Terrain",
+    "Hex",
+    "GameConfig",
+]

--- a/wargame/config.py
+++ b/wargame/config.py
@@ -1,0 +1,40 @@
+"""Configuration helpers for setting up a game."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from .player import Player
+from .game import Game
+
+
+@dataclass
+class GameConfig:
+    """Convenience dataclass holding game setup parameters.
+
+    Attributes
+    ----------
+    width, height:
+        Dimensions of the hex map.
+    seed:
+        Random seed used by the map generator.  The same seed results in
+        identical maps which enables reproducible matches.
+    players:
+        List of player names participating in the match.  The length of the
+        list decides the number of players.  Between 2 and 4 players are
+        supported by the current map generator.
+    money, oil:
+        Starting resources for each player.
+    """
+
+    width: int = 10
+    height: int = 10
+    seed: Optional[int] = None
+    players: List[str] = field(default_factory=lambda: ["Player1", "Player2"])
+    money: int = 1000
+    oil: int = 500
+
+    def create_game(self) -> Game:
+        """Create a :class:`Game` instance based on this configuration."""
+        player_objs = [Player(name=p, money=self.money, oil=self.oil) for p in self.players]
+        return Game.create(player_objs, width=self.width, height=self.height, seed=self.seed)

--- a/wargame/game.py
+++ b/wargame/game.py
@@ -1,0 +1,117 @@
+"""Core game logic implementing turn order and main mechanics."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict, Tuple, Iterable
+
+from .map import Map, Terrain
+from .player import Player
+from .units import Unit
+
+
+@dataclass
+class Game:
+    players: Dict[str, Player]
+    game_map: Map
+    turn_order: List[str]
+    current_player_idx: int = 0
+
+    @classmethod
+    def create(cls, players: List[Player], width: int = 10, height: int = 10, seed: int | None = None) -> "Game":
+        game_map = Map(width, height, seed, players=len(players))
+        player_dict = {p.name: p for p in players}
+        # Assign capitals
+        for p, pos in zip(players, game_map.capitals):
+            p.capital = pos
+            game_map.get_hex(pos).owner = p.name
+        turn_order = [p.name for p in players]
+        return cls(player_dict, game_map, turn_order)
+
+    @property
+    def current_player(self) -> Player:
+        return self.players[self.turn_order[self.current_player_idx]]
+
+    def next_player(self) -> None:
+        self.current_player_idx = (self.current_player_idx + 1) % len(self.turn_order)
+
+    # --- Economy ---------------------------------------------------------
+    def calcular_ingresos(self, player: Player) -> Tuple[int, int]:
+        capitals = 0
+        city_large = 0
+        city_small = 0
+        territory = 0
+        oil_wells = 0
+        stations = 0
+        for coord, hex in self.game_map.hexes.items():
+            if hex.owner != player.name:
+                continue
+            if hex.structure == Terrain.CITY_CAPITAL:
+                capitals += 1
+            elif hex.structure == Terrain.CITY_LARGE:
+                city_large += 1
+            elif hex.structure == Terrain.CITY_SMALL:
+                city_small += 1
+            elif hex.structure == Terrain.OIL_WELL:
+                oil_wells += 1
+            elif hex.structure == Terrain.STATION:
+                stations += 1
+            else:
+                territory += 1
+        dinero = 50 * capitals + 30 * city_large + 15 * city_small + 3 * territory
+        petroleo_base = 10 * oil_wells
+        petroleo = round(petroleo_base * (1 + 0.10 * stations))
+        return dinero, petroleo
+
+    def end_round(self) -> None:
+        for player in self.players.values():
+            d, p = self.calcular_ingresos(player)
+            player.money += d
+            player.oil += p
+
+    # --- Movement --------------------------------------------------------
+    def mover_unidad(self, player: Player, unit: Unit, path: Iterable[Tuple[int, int]]) -> None:
+        """Move a unit along the given path.
+
+        `path` is an iterable of coordinates excluding the unit's current position.
+        The function calculates movement points and oil consumption according to
+        terrain costs.
+        """
+
+        pm_usados = 0.0
+        oil_necesario = 0.0
+        current = unit.position
+        for step in path:
+            hex = self.game_map.get_hex(step)
+            cost = unit.movement_cost(hex.terrain)
+            pm_usados += cost
+            oil_necesario += cost * unit.utype.tpm
+            current = step
+        if pm_usados > unit.utype.pm:
+            raise ValueError("Movimiento excede PM disponible")
+        if player.oil < oil_necesario:
+            raise ValueError("Petróleo insuficiente")
+        player.oil -= oil_necesario
+        # Update position and ownership
+        unit.position = current
+        self.game_map.get_hex(current).owner = player.name
+
+    # --- Capture ---------------------------------------------------------
+    def capturar_capital(self, attacker: Unit) -> None:
+        hex = self.game_map.get_hex(attacker.position)
+        if hex.structure != Terrain.CITY_CAPITAL:
+            return
+        defender_name = hex.owner
+        if defender_name is None or defender_name == attacker.owner:
+            return
+        defender = self.players[defender_name]
+        # Transfer units
+        transferred = defender.remove_all_units()
+        for u in transferred:
+            u.owner = attacker.owner
+            self.players[attacker.owner].units.append(u)
+        defender.alive = False
+        hex.owner = attacker.owner
+
+    # --- Utility ---------------------------------------------------------
+    def players_alive(self) -> List[Player]:
+        return [p for p in self.players.values() if p.alive]

--- a/wargame/map.py
+++ b/wargame/map.py
@@ -1,0 +1,132 @@
+"""Map generation and terrain handling for the strategy game."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+import random
+from typing import Dict, Tuple, Optional, List
+
+
+class Terrain(Enum):
+    """Basic terrain types used on the hex map."""
+
+    PLAIN = "plain"
+    HILL = "hill"
+    MOUNTAIN = "mountain"
+    FOREST = "forest"
+    SWAMP = "swamp"
+    RIVER = "river"
+    ROAD = "road"
+    RAIL = "rail"
+    RUINS = "ruins"
+    CITY_CAPITAL = "city_capital"
+    CITY_LARGE = "city_large"
+    CITY_SMALL = "city_small"
+    OIL_WELL = "oil_well"
+    STATION = "station"
+
+
+# Movement cost (movement points) for infantry units. Vehicles have special cases
+INF_MOVEMENT_COST: Dict[Terrain, float] = {
+    Terrain.PLAIN: 1.0,
+    Terrain.ROAD: 0.5,
+    Terrain.HILL: 1.5,
+    Terrain.FOREST: 2.0,
+    Terrain.SWAMP: 3.0,
+    Terrain.MOUNTAIN: 3.0,  # only some units can enter
+    Terrain.RIVER: float("inf"),
+}
+
+VEHICLE_MOVEMENT_COST: Dict[Terrain, float] = {
+    Terrain.PLAIN: 1.0,
+    Terrain.ROAD: 0.5,
+    Terrain.HILL: 1.5,
+    Terrain.FOREST: 3.0,
+    Terrain.SWAMP: 4.0,
+    Terrain.MOUNTAIN: float("inf"),
+    Terrain.RIVER: float("inf"),
+}
+
+
+@dataclass
+class Hex:
+    """Single hex tile on the map."""
+
+    terrain: Terrain = Terrain.PLAIN
+    owner: Optional[str] = None  # player's name
+    structure: Optional[Terrain] = None  # e.g. city, oil well, station
+
+
+class Map:
+    """Hex map consisting of terrain and structures.
+
+    The map uses axial coordinates (q, r) for hexes.  Generation is deterministic
+    given a random seed so that the same seed results in the same map layout.
+    """
+
+    def __init__(self, width: int, height: int, seed: Optional[int] = None, players: int = 2):
+        self.width = width
+        self.height = height
+        self.hexes: Dict[Tuple[int, int], Hex] = {}
+        self.capitals: List[Tuple[int, int]] = []
+        if seed is not None:
+            random.seed(seed)
+        self._generate(players)
+
+    # Directions for axial coordinates (q, r)
+    DIRECTIONS = [(1, 0), (1, -1), (0, -1), (-1, 0), (-1, 1), (0, 1)]
+
+    def _generate(self, players: int) -> None:
+        """Generate map terrain and place capitals.
+
+        For simplicity the terrain is largely plains with some random features.
+        Capitals are placed in symmetric positions based on the number of players.
+        """
+
+        terrains = [Terrain.PLAIN] * 6 + [Terrain.FOREST, Terrain.HILL, Terrain.SWAMP]
+
+        for q in range(self.width):
+            for r in range(self.height):
+                self.hexes[(q, r)] = Hex(terrain=random.choice(terrains))
+
+        # place capitals
+        positions = {
+            2: [(0, 0), (self.width - 1, self.height - 1)],
+            3: [(0, 0), (self.width - 1, 0), (self.width // 2, self.height - 1)],
+            4: [(0, 0), (self.width - 1, 0), (self.width - 1, self.height - 1), (0, self.height - 1)],
+        }
+        cap_positions = positions.get(players)
+        if not cap_positions or len(cap_positions) < players:
+            raise ValueError("Players must be between 2 and 4")
+        for pos in cap_positions[:players]:
+            self.hexes[pos].terrain = Terrain.CITY_CAPITAL
+            self.hexes[pos].structure = Terrain.CITY_CAPITAL
+            self.capitals.append(pos)
+
+        # Randomly place oil wells and stations
+        free_hexes = [coord for coord, h in self.hexes.items() if h.structure is None]
+        random.shuffle(free_hexes)
+        for i in range(max(1, self.width // 5)):
+            if not free_hexes:
+                break
+            coord = free_hexes.pop()
+            self.hexes[coord].terrain = Terrain.OIL_WELL
+            self.hexes[coord].structure = Terrain.OIL_WELL
+        for i in range(max(1, self.width // 6)):
+            if not free_hexes:
+                break
+            coord = free_hexes.pop()
+            self.hexes[coord].terrain = Terrain.STATION
+            self.hexes[coord].structure = Terrain.STATION
+
+    def get_hex(self, coord: Tuple[int, int]) -> Hex:
+        return self.hexes[coord]
+
+    def neighbors(self, coord: Tuple[int, int]) -> List[Tuple[int, int]]:
+        q, r = coord
+        result = []
+        for dq, dr in self.DIRECTIONS:
+            nq, nr = q + dq, r + dr
+            if (nq, nr) in self.hexes:
+                result.append((nq, nr))
+        return result

--- a/wargame/player.py
+++ b/wargame/player.py
@@ -1,0 +1,30 @@
+"""Player representation and economy handling."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Tuple
+
+from .map import Map, Terrain
+from .units import Unit, UNIT_TYPES, UnitType
+
+
+@dataclass
+class Player:
+    name: str
+    money: int = 1000
+    oil: int = 500
+    stars: int = 0
+    units: List[Unit] = field(default_factory=list)
+    capital: Tuple[int, int] | None = None
+    alive: bool = True
+
+    def add_unit(self, utype: str, position: Tuple[int, int]) -> Unit:
+        unit_type = UNIT_TYPES[utype]
+        unit = Unit(owner=self.name, utype=unit_type, position=position)
+        self.units.append(unit)
+        return unit
+
+    def remove_all_units(self) -> List[Unit]:
+        units = self.units
+        self.units = []
+        return units

--- a/wargame/units.py
+++ b/wargame/units.py
@@ -1,0 +1,40 @@
+"""Unit definitions and movement handling."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from .map import Terrain, INF_MOVEMENT_COST, VEHICLE_MOVEMENT_COST
+
+
+@dataclass
+class UnitType:
+    """Definition of a unit type including economic and movement stats."""
+
+    name: str
+    money_cost: int
+    oil_cost: int
+    tpm: float  # Oil consumption per movement point
+    pm: int  # Movement points
+    vehicle: bool = False
+
+
+# Basic unit types based on GDD
+UNIT_TYPES: Dict[str, UnitType] = {
+    "INF_BASIC": UnitType("Infanteria basica", money_cost=60, oil_cost=0, tpm=0.0, pm=4, vehicle=False),
+    "INF_HEAVY": UnitType("Infanteria pesada", money_cost=90, oil_cost=0, tpm=0.0, pm=3, vehicle=False),
+    "RECON": UnitType("Reconocimiento", money_cost=80, oil_cost=20, tpm=1.0, pm=6, vehicle=True),
+    "TANK_MEDIUM": UnitType("Tanque medio", money_cost=300, oil_cost=45, tpm=1.5, pm=5, vehicle=True),
+}
+
+
+@dataclass
+class Unit:
+    owner: str
+    utype: UnitType
+    position: Tuple[int, int]
+    hp: int = 10
+
+    def movement_cost(self, terrain: Terrain) -> float:
+        table = VEHICLE_MOVEMENT_COST if self.utype.vehicle else INF_MOVEMENT_COST
+        return table.get(terrain, float("inf"))


### PR DESCRIPTION
## Summary
- introduce `GameConfig` dataclass for specifying map size, seed, player names, and starting resources
- expose configuration via package and add test ensuring custom setup works

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c18c7b448331a60a94c307aadbe4